### PR TITLE
fix: Proteção da rota de Detalhes de uma Task

### DIFF
--- a/task/views.py
+++ b/task/views.py
@@ -1,8 +1,11 @@
+from typing import Any
+from django.shortcuts import redirect
 from django.views.generic.list import ListView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib import messages
 
 from task.models import Task
 
@@ -31,6 +34,19 @@ class DetailTask(LoginRequiredMixin, DetailView):
     template_name = 'task_detail.html'
     model = Task
     context_object_name = 'task'
+
+    def get(self, request, *args, **kwargs):
+        try:
+            task = self.get_object()
+
+            if task.user == request.user:
+                return super().get(request, *args, **kwargs)
+            else:
+                messages.add_message(request, messages.WARNING, 'A tarefa que você está procurando não foi encontrada.')
+                return redirect(reverse('task-list'))
+        except:
+            messages.error(request, 'A tarefa que você está procurando não foi encontrada.')
+            return reverse_lazy('task_list')
 
 
 class CreateTask(LoginRequiredMixin, CreateView):

--- a/templates/template_main.html
+++ b/templates/template_main.html
@@ -8,6 +8,17 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
     </head>
     <body>
+        {% if messages %}
+            <div id="message-container" class="message-alert-container">
+                <div class="alert alert-warning alert-dismissible message-alert" role="alert">
+                    {% for message in messages %}
+                        {{ message }}
+                    {% endfor %}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+            </div>
+        {% endif %}
+
         {% block main %}
 
         {% endblock %}
@@ -18,3 +29,30 @@
         {% endblock %}
     </body>
 </html>
+
+<style>
+    .message-alert-container {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        flex-wrap: nowrap;
+        align-items: center;
+        padding-top: 15px;
+        position: fixed;
+        width: 100%;
+    }
+
+    .message-alert {
+        width: 50%;
+    }
+</style>
+
+<script>
+    setTimeout(function() {
+        var elemento = document.getElementById("message-container");
+
+        if (elemento) {
+            elemento.style.display = "none";
+        }
+    }, 5000);
+</script>


### PR DESCRIPTION
### Passos da solução:
1. Criação de um filtro no método responsável pelo retorno da resposta HTTP  do detalhe da Task.
2. Redirecionamento da pagina de Detalhes para a Listagem das Tasks.
3. Exibição de uma mensagem de aviso sobre o ocorrido.

### Capturas de tela do fluxo:
1. Pagina inicial ![image](https://github.com/waleson-melo/ToDoList/assets/64645685/e3458a76-1879-4317-89e3-52524a64457a)
2. Pagina detalhes 
![image](https://github.com/waleson-melo/ToDoList/assets/64645685/95ce5364-7fbc-424d-a99a-3dac394517ea)
3. Edição do ID da task, era 2, coloquei 1 
![image](https://github.com/waleson-melo/ToDoList/assets/64645685/73f8ea8d-2468-468f-9de6-bc53fa73166c)
4. Por fim, ao tentar acessar a nova URL o sistema redireciona o usuário e mostra uma mensagem 
![image](https://github.com/waleson-melo/ToDoList/assets/64645685/be681937-7936-4796-9a83-984f185e3156)
