### PR TITLE
fix: Proteção da rota de Editar uma Task

### DIFF
--- a/task/views.py
+++ b/task/views.py
@@ -73,6 +73,19 @@ class UpdateTask(LoginRequiredMixin, UpdateView):
     fields = ['title', 'description', 'complete']
     success_url = reverse_lazy('task-list')
 
+    def get(self, request, *args, **kwargs):
+        try:
+            task = self.get_object()
+
+            if task.user == request.user:
+                return super().get(request, *args, **kwargs)
+            else:
+                messages.add_message(request, messages.WARNING, 'A tarefa que você está procurando não foi encontrada.')
+                return redirect(reverse('task-list'))
+        except:
+            messages.error(request, 'A tarefa que você está procurando não foi encontrada.')
+            return reverse_lazy('task_list')
+
     def get_context_data(self, **kwargs):
         context = super(UpdateTask, self).get_context_data(**kwargs)
         context['page_name'] = 'Atualizar Tarefa'


### PR DESCRIPTION
### Passos da solução:
1. Criação de um filtro no método responsável pelo retorno da resposta HTTP da view de Editar Task.
2. Redirecionamento da pagina de Edição para a Listagem das Tasks.
3. Exibição de uma mensagem de aviso sobre o ocorrido.

### Capturas de tela do fluxo:
1. Pagina inicial 
![image](https://github.com/waleson-melo/ToDoList/assets/64645685/03e6b1bd-a733-4ac1-9687-127bce31e7d1)
2. Pagina editar 
![image](https://github.com/waleson-melo/ToDoList/assets/64645685/9abaf5a5-1333-4302-831e-8e51736db8cf)
3. Edição do ID da task, era 2, coloquei 1 
![image](https://github.com/waleson-melo/ToDoList/assets/64645685/b65dbca3-50c2-4803-8050-5219830f54c1)

4. Por fim, ao tentar acessar a nova URL o sistema redireciona o usuário e mostra uma mensagem 
![image](https://github.com/waleson-melo/ToDoList/assets/64645685/c37c5872-d24c-437b-9203-69fc492f3618)

